### PR TITLE
Reduce the Number of calls to APPCMD

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -176,9 +176,9 @@ HRESULT IISConfigUtil::RunCommand(wstring * pstrCmd, BOOL fIgnoreError)
     DWORD       dwStatus = 0;
     PROCESS_INFORMATION pi;
 
-	ZeroMemory(&si, sizeof(STARTUPINFO));
-	si.cb = sizeof(STARTUPINFO);
-	si.dwFlags |= STARTF_USESTDHANDLES;
+    ZeroMemory(&si, sizeof(STARTUPINFO));
+    si.cb = sizeof(STARTUPINFO);
+    si.dwFlags |= STARTF_USESTDHANDLES;
 
     if (!CreateProcess(NULL,
         (LPWSTR)pstrCmd->c_str(),
@@ -195,8 +195,8 @@ HRESULT IISConfigUtil::RunCommand(wstring * pstrCmd, BOOL fIgnoreError)
         goto Finished;
     }
 
-	// wait for at most 5 seconds to allow APPCMD finish
-	WaitForSingleObject(pi.hProcess, 5000);
+    // wait for at most 5 seconds to allow APPCMD finish
+    WaitForSingleObject(pi.hProcess, 5000);
     if ((!GetExitCodeProcess(pi.hProcess, &dwStatus) || dwStatus != 0) && (!fIgnoreError))
     {
         //

--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -135,34 +135,34 @@ HRESULT IISConfigUtil::BuildAppCmdCommand(unordered_map<wstring, wstring> envSet
         hr = ERROR_OUTOFMEMORY;
         goto Finished;
     }
-	pstrCmd->append(m_pstrSysDirPath);
-	pstrCmd->append(L"\\inetsrv\\appcmd.exe set config -section:system.applicationHost/applicationPools ");
+    pstrCmd->append(m_pstrSysDirPath);
+    pstrCmd->append(L"\\inetsrv\\appcmd.exe set config -section:system.applicationHost/applicationPools ");
 
-	for (auto it = envSet.begin(); it != envSet.end(); ++it)
-	{
-		wstring strEnvName = it->first;
-		wstring strEnvValue = it->second;
-		if (fAddCommand)
-		{
-			pstrCmd->append(L"/+\"[name='");
-		}
-		else
-		{
-			pstrCmd->append(L"/-\"[name='");
+    for (auto it = envSet.begin(); it != envSet.end(); ++it)
+    {
+        wstring strEnvName = it->first;
+        wstring strEnvValue = it->second;
+        if (fAddCommand)
+        {
+            pstrCmd->append(L"/+\"[name='");
+        }
+        else
+        {
+            pstrCmd->append(L"/-\"[name='");
 
-		}
-		pstrCmd->append(pstrAppPoolName);
-		pstrCmd->append(L"'].environmentVariables.[name='");
-		pstrCmd->append(strEnvName);
-		if (fAddCommand)
-		{
-			pstrCmd->append(L"',value='");
-			pstrCmd->append(strEnvValue);
-		}
-		pstrCmd->append(L"']\" ");
-	}
-	pstrCmd->append(L" /commit:apphost");
-	*pStrCmd = pstrCmd;
+        }
+        pstrCmd->append(pstrAppPoolName);
+        pstrCmd->append(L"'].environmentVariables.[name='");
+        pstrCmd->append(strEnvName);
+        if (fAddCommand)
+        {
+            pstrCmd->append(L"',value='");
+            pstrCmd->append(strEnvValue);
+        }
+        pstrCmd->append(L"']\" ");
+    }
+    pstrCmd->append(L" /commit:apphost");
+    *pStrCmd = pstrCmd;
 
 Finished:
     return hr;
@@ -228,8 +228,8 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
     wstring* pstrAddCmd     = NULL;
     wstring* pstrRmCmd      = NULL;
 
-	unordered_map<wstring, LPTSTR> filter;
-	unordered_map<wstring, wstring> envSet;
+    unordered_map<wstring, LPTSTR> filter;
+    unordered_map<wstring, wstring> envSet;
     POPULATE(filter) ;
 
     lpvEnv = GetEnvironmentStrings();
@@ -260,43 +260,43 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
                 
                 continue;
             }
-			wstring * pStrTempName = new wstring();
-			pStrTempName->append(pstrName);
-			wstring * pStrTempValue = new wstring();
-			pStrTempValue->append(pstrValue);
+            wstring * pStrTempName = new wstring();
+            pStrTempName->append(pstrName);
+            wstring * pStrTempValue = new wstring();
+            pStrTempValue->append(pstrValue);
 
-			envSet.insert(KV_WSTR(*pStrTempName, *pStrTempValue));
+            envSet.insert(KV_WSTR(*pStrTempName, *pStrTempValue));
             
             pEqualChar[0] = L'=';
 
-		}
+        }
         //
         // move to next environment variable
         //
         lpszVariable += lstrlen(lpszVariable) + 1;
     }
 
-	hr = BuildAppCmdCommand(envSet, pstrAppPoolName, &pstrAddCmd, TRUE);
-	if (FAILED(hr))
-	{
-		goto Finished;
-	}
+    hr = BuildAppCmdCommand(envSet, pstrAppPoolName, &pstrAddCmd, TRUE);
+    if (FAILED(hr))
+    {
+        goto Finished;
+    }
 
-	hr = BuildAppCmdCommand(envSet, pstrAppPoolName, &pstrRmCmd, FALSE);
-	if (FAILED(hr))
-	{
-		goto Finished;
-	}
+    hr = BuildAppCmdCommand(envSet, pstrAppPoolName, &pstrRmCmd, FALSE);
+    if (FAILED(hr))
+    {
+        goto Finished;
+    }
 
-	//allow appcmd to fail if it is trying to remove environment variable
-	RunCommand(pstrRmCmd, TRUE);
-	//appcmd must success when add new environment variable
-	hr = RunCommand(pstrAddCmd, FALSE);
+    //allow appcmd to fail if it is trying to remove environment variable
+    RunCommand(pstrRmCmd, TRUE);
+    //appcmd must success when add new environment variable
+    hr = RunCommand(pstrAddCmd, FALSE);
 
-	if (FAILED(hr))
-	{
-		goto Finished;
-	}
+    if (FAILED(hr))
+    {
+        goto Finished;
+    }
 
 Finished:
     if (lpvEnv != NULL)

--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -129,14 +129,14 @@ HRESULT IISConfigUtil::BuildAppCmdCommand(unordered_map<wstring, wstring> envSet
     _ASSERT(strEnvValue != NULL);
     _ASSERT(pstrAppPoolName != NULL);
 
-    wstring* pstr = new wstring();
-    if (pstr == NULL)
+    wstring* pstrCmd = new wstring();
+    if (pstrCmd == NULL)
     {
         hr = ERROR_OUTOFMEMORY;
         goto Finished;
     }
-	pstr->append(m_pstrSysDirPath);
-	pstr->append(L"\\inetsrv\\appcmd.exe set config -section:system.applicationHost/applicationPools ");
+	pstrCmd->append(m_pstrSysDirPath);
+	pstrCmd->append(L"\\inetsrv\\appcmd.exe set config -section:system.applicationHost/applicationPools ");
 
 	for (auto it = envSet.begin(); it != envSet.end(); ++it)
 	{
@@ -144,31 +144,25 @@ HRESULT IISConfigUtil::BuildAppCmdCommand(unordered_map<wstring, wstring> envSet
 		wstring strEnvValue = it->second;
 		if (fAddCommand)
 		{
-			pstr->append(L"/+\"[name='");
+			pstrCmd->append(L"/+\"[name='");
 		}
 		else
 		{
-			pstr->append(L"/-\"[name='");
+			pstrCmd->append(L"/-\"[name='");
 
 		}
-		pstr->append(pstrAppPoolName);
-		pstr->append(L"'].environmentVariables.[name='");
-		pstr->append(strEnvName);
+		pstrCmd->append(pstrAppPoolName);
+		pstrCmd->append(L"'].environmentVariables.[name='");
+		pstrCmd->append(strEnvName);
 		if (fAddCommand)
 		{
-			pstr->append(L"',value='");
-			pstr->append(strEnvValue);
+			pstrCmd->append(L"',value='");
+			pstrCmd->append(strEnvValue);
 		}
-		pstr->append(L"']\" ");
+		pstrCmd->append(L"']\" ");
 	}
-	pstr->append(L" /commit:apphost");
-	*pStrCmd = pstr;
-
-	///////////////////////DEBUG//////////////////////////////
-	wcout << *pstr << endl;
-	wcout << endl;
-	wcout << endl;
-	///////////////////////DEBUG//////////////////////////////
+	pstrCmd->append(L" /commit:apphost");
+	*pStrCmd = pstrCmd;
 
 Finished:
     return hr;

--- a/src/ServiceMonitor/IISConfigUtil.h
+++ b/src/ServiceMonitor/IISConfigUtil.h
@@ -19,7 +19,7 @@ public:
 
 private:
     HRESULT RunCommand(std::wstring * pstrCmd);
-    HRESULT BuildAppCmdCommand(WCHAR*  strEnvName, WCHAR* strEnvValue, WCHAR* pstrAppPoolName, std::wstring** pStrCmd, BOOL fAddCommand);
+    HRESULT BuildAppCmdCommand(std::unordered_map<std::wstring, std::wstring> envSet, WCHAR* pstrAppPoolName, std::wstring** pStrCmd, BOOL fAddCommand);
     BOOL    FilterEnv(std::unordered_map<std::wstring, LPTSTR> filter, LPTSTR strEnvName, LPTSTR strEnvValue);
     TCHAR*  m_pstrSysDirPath;
 };

--- a/src/ServiceMonitor/IISConfigUtil.h
+++ b/src/ServiceMonitor/IISConfigUtil.h
@@ -18,7 +18,7 @@ public:
     HRESULT UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName);
 
 private:
-    HRESULT RunCommand(std::wstring * pstrCmd);
+    HRESULT RunCommand(std::wstring * pstrCmd, BOOL fIgnoreError);
     HRESULT BuildAppCmdCommand(std::unordered_map<std::wstring, std::wstring> envSet, WCHAR* pstrAppPoolName, std::wstring** pStrCmd, BOOL fAddCommand);
     BOOL    FilterEnv(std::unordered_map<std::wstring, LPTSTR> filter, LPTSTR strEnvName, LPTSTR strEnvValue);
     TCHAR*  m_pstrSysDirPath;


### PR DESCRIPTION
ServiceMonitor use to call AppCmd twice per environment variable, which has a huge impact on container startup time.

Implements:
Combine appcmd calls together by operates multiple environment variable as once.

EX.
.\appcmd.exe set config -section:system.applicationHost/applicationPools /+"[name='DefaultAppPool'].environmentVariables.[name='foo1',value='bar1']"   /commit:apphost

.\appcmd.exe set config -section:system.applicationHost/applicationPools /+"[name='DefaultAppPool'].environmentVariables.[name='foo2',value='bar2]"   /commit:apphost

is now accomplished in one call

.\appcmd.exe set config -section:system.applicationHost/applicationPools /+"[name='DefaultAppPool'].environmentVariables.[name='foo1',value='bar1']"  /+"[name='DefaultAppPool'].environmentVariables.[name='foo2',value='bar2']"     /commit:apphost

Service will only call appcmd twice:
1 Remove all the environment variable from applicationHost.config.
2 Add all the environment variable to applicationHost.config.