### PR TITLE
Fix typo in shutdown message

### DIFF
--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -14,7 +14,7 @@ VOID CtrlHandle(DWORD dwCtrlType)
     case CTRL_BREAK_EVENT:
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
-        _tprintf(L"\nTerminating the process due to CTRL signal was received.\n");
+        _tprintf(L"\nCTRL signal received. The process will now terminate.\n");
         SetEvent(g_hStopEvent);
         g_hStopEvent = INVALID_HANDLE_VALUE;
         break;

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -14,7 +14,7 @@ VOID CtrlHandle(DWORD dwCtrlType)
     case CTRL_BREAK_EVENT:
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
-        _tprintf(L"\nTerminating the process due to CTRL signal was recevied.\n");
+        _tprintf(L"\nTerminating the process due to CTRL signal was received.\n");
         SetEvent(g_hStopEvent);
         g_hStopEvent = INVALID_HANDLE_VALUE;
         break;


### PR DESCRIPTION
Small typo there.
I also think the way the message reads is a bit weird right now.