### PR TITLE
SERVICE_START_PENDING State is Not Handled Properly

### DIFF
--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -135,38 +135,10 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
         hr = GetServiceHandle(pServiceName, &hService);
         if (SUCCEEDED(hr)) 
         {
-            if (!QueryServiceStatusEx(hService,
-                SC_STATUS_PROCESS_INFO,
-                (LPBYTE)&sStatus,
-                sizeof(SERVICE_STATUS_PROCESS),
-                &dwBytes))
-            {
-                hr = HRESULT_FROM_WIN32(GetLastError());
-                goto Finished;
-            }
-
-            if (sStatus.dwCurrentState == SERVICE_STOPPED) 
-            {
-                //
-                // Service has already been stopped, no action needed
-                //
-                goto Finished;
-            }
-            else if (sStatus.dwCurrentState != SERVICE_STOP_PENDING)
-            {
-                //
-                // Sending stop signal
-                //
-                if (!ControlService(hService, SERVICE_CONTROL_STOP, (LPSERVICE_STATUS)&sStatus))
-                {
-                    hr = HRESULT_FROM_WIN32(GetLastError());
-                    goto Finished;
-                }
-            }
-
             while (dwRemainTime >0)
             {
                 DWORD     dwBytes = 0;
+                _tprintf(L"\n FUnction Begin'%s' error [%x]\n", pServiceName, hr);
 
                 if (!QueryServiceStatusEx(hService,
                     SC_STATUS_PROCESS_INFO,
@@ -174,6 +146,8 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
                     sizeof(SERVICE_STATUS_PROCESS),
                     &dwBytes))
                 {
+                    _tprintf(L"\n The Second Query Failed'%s' error [%x]\n", pServiceName, hr);
+
                     hr = HRESULT_FROM_WIN32(GetLastError());
                     goto Finished;
                 }
@@ -181,18 +155,27 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
                 {
                     goto Finished;
                 }
-                else if (sStatus.dwCurrentState == SERVICE_STOP_PENDING)
+                else if (sStatus.dwCurrentState == SERVICE_STOP_PENDING || sStatus.dwCurrentState == SERVICE_START_PENDING || sStatus.dwCurrentState == SERVICE_PAUSE_PENDING || sStatus.dwCurrentState == SERVICE_CONTINUE_PENDING)
                 {
                     dwSleepTime = rand() % 10 + 1;
                     dwSleepTime = dwSleepTime < dwRemainTime ? dwSleepTime : dwRemainTime;
                     dwRemainTime -= dwSleepTime;
                     Sleep(dwSleepTime * 1000);
                 }
+                else if (sStatus.dwCurrentState == SERVICE_RUNNING || sStatus.dwCurrentState == SERVICE_PAUSED)
+                {
+                    if (!ControlService(hService, SERVICE_CONTROL_STOP, (LPSERVICE_STATUS)&sStatus))
+                    {
+                        hr = HRESULT_FROM_WIN32(GetLastError());
+                        goto Finished;
+                    }
+                }
                 else
                 {
                     //
                     // Service fails to stop 
                     //
+                    _tprintf(L"\n ACTUAL STOP REQUEST '%s' error [%x]  [%x]\n", pServiceName, hr, sStatus.dwCurrentState);
                     hr = E_FAIL;
                     goto Finished;
                 }

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -138,16 +138,12 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
             while (dwRemainTime >0)
             {
                 DWORD     dwBytes = 0;
-                _tprintf(L"\n FUnction Begin'%s' error [%x]\n", pServiceName, hr);
-
                 if (!QueryServiceStatusEx(hService,
                     SC_STATUS_PROCESS_INFO,
                     (LPBYTE)&sStatus,
                     sizeof(SERVICE_STATUS_PROCESS),
                     &dwBytes))
                 {
-                    _tprintf(L"\n The Second Query Failed'%s' error [%x]\n", pServiceName, hr);
-
                     hr = HRESULT_FROM_WIN32(GetLastError());
                     goto Finished;
                 }
@@ -175,7 +171,6 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
                     //
                     // Service fails to stop 
                     //
-                    _tprintf(L"\n ACTUAL STOP REQUEST '%s' error [%x]  [%x]\n", pServiceName, hr, sStatus.dwCurrentState);
                     hr = E_FAIL;
                     goto Finished;
                 }


### PR DESCRIPTION
Bug fix for serviceMonitor.exe is trying to stop the w3svc service while w3svc is in STOP_PENDING state.