### PR TITLE
Make AppPool name configurable

### DIFF
--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -49,7 +49,8 @@ int __cdecl _tmain(int argc, _TCHAR* argv[])
         // we hardcode this behavior for now. We can add an input switch later if needed
         //
         WCHAR* pstrAppPoolName = L"DefaultAppPool";
-        if (argc > 2) {
+        if (argc > 2)
+        {
             pstrAppPoolName = argv[2];
         }
         IISConfigUtil configHelper = IISConfigUtil();

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -30,7 +30,11 @@ int __cdecl _tmain(int argc, _TCHAR* argv[])
 
     if (argc <= 1)
     {
-        _tprintf(L"\nUSAGE: %s [windows service name]\n", argv[0]);
+		_tprintf(L"\nUSAGE: %s [windows service name]", argv[0]);
+		_tprintf(L"\n       %s w3svc [application pool]", argv[0]);
+		_tprintf(L"\n\nOptions:");
+		_tprintf(L"\n    windows service name    Name of the Windows service to monitor");
+		_tprintf(L"\n    application pool        Name of the application pool to monitor; defaults to DefaultAppPool\n");
         goto Finished;
     }
 

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -48,9 +48,13 @@ int __cdecl _tmain(int argc, _TCHAR* argv[])
         // iis scenario, update the environment variable
         // we hardcode this behavior for now. We can add an input switch later if needed
         //
+        WCHAR* pstrAppPoolName = L"DefaultAppPool";
+        if (argc > 2) {
+            pstrAppPoolName = argv[2];
+        }
         IISConfigUtil configHelper = IISConfigUtil();
         if( FAILED(hr = configHelper.Initialize()) ||
-            FAILED(hr = configHelper.UpdateEnvironmentVarsToConfig(L"DefaultAppPool")))
+            FAILED(hr = configHelper.UpdateEnvironmentVarsToConfig(pstrAppPoolName)))
         {
             _tprintf(L"\nFailed to update IIS configuration\n");
             goto Finished;


### PR DESCRIPTION
_Requirement_: Security hardened IIS with just the necessary features - including removed default web site and default app pool
_Problem_: ServerMonitor expects a pool DefaulAppPool, fails when it is missing and doesn't provide a override-able option
_Within this PR_: added an extra argument if the pool name needs to be changed

**Dockerfile**:
```Dockerfile
FROM microsoft/aspnet:4.7.1-windowsservercore-ltsc2016

RUN Get-ChildItem IIS:\Sites | Remove-Website; \
    Get-ChildItem IIS:\AppPools | Remove-WebAppPool;

RUN New-WebAppPool SomePool;

#uncomment for new behavior
#COPY x64/Debug/ServiceMonitor.exe /ServiceMonitor2.exe
#ENTRYPOINT ["C:\\ServiceMonitor2.exe", "w3svc", "SomePool"]
```

when starting the container the ServiceMonitor cannot find the DefaultAppPool pool and fails with:
```
 Service 'w3svc' has been stopped

APPCMD failed with error code 4312

Failed to update IIS configuration
```
using my code changes (and uncomment the Dockerfile lines) the result is :
```
 Service 'w3svc' has been stopped

 Service 'w3svc' started
```