### PR TITLE
Prevent environment variables names from being converted to upper case

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -260,24 +260,14 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
 
 
             pEqualChar[0] = L'\0';
-			LPTSTR pstrNameCheck = _tcsdup(pstrName);
-            if (FilterEnv(filter, CharUpper(pstrNameCheck), pstrValue))
+            wstring strNameCheck(pstrName);
+            if (FilterEnv(filter, CharUpper((LPWSTR)strNameCheck.c_str()), pstrValue))
             {
                 pEqualChar[0] = L'=';
                 lpszVariable += lstrlen(lpszVariable) + 1;
                 
-				if (pstrNameCheck != NULL)
-				{
-					delete pstrNameCheck;
-					pstrNameCheck = NULL;
-				}
                 continue;
             }
-			if (pstrNameCheck != NULL)
-			{
-				delete pstrNameCheck;
-				pstrNameCheck = NULL;
-			}
 
             envVec.emplace_back(wstring(pstrName), wstring(pstrValue));
 

--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -260,13 +260,24 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
 
 
             pEqualChar[0] = L'\0';
-            if (FilterEnv(filter, CharUpper(pstrName), pstrValue))
+			LPTSTR pstrNameCheck = _tcsdup(pstrName);
+            if (FilterEnv(filter, CharUpper(pstrNameCheck), pstrValue))
             {
                 pEqualChar[0] = L'=';
                 lpszVariable += lstrlen(lpszVariable) + 1;
                 
+				if (pstrNameCheck != NULL)
+				{
+					delete pstrNameCheck;
+					pstrNameCheck = NULL;
+				}
                 continue;
             }
+			if (pstrNameCheck != NULL)
+			{
+				delete pstrNameCheck;
+				pstrNameCheck = NULL;
+			}
 
             envVec.emplace_back(wstring(pstrName), wstring(pstrValue));
 


### PR DESCRIPTION
This change will prevent automatic conversion of environment variables to upper case when adding to the app pool.
Automatic case conversion is not ideal as it breaks ConfigBuilders and other code that searches for environment variables with exact case.

