### PR TITLE
Handle environment variables with single or double quotes

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -131,6 +131,17 @@ Finished:
     return hr;
 }
 
+void IISConfigUtil::Replace(std::wstring& str, std::wstring oldValue, std::wstring newValue)
+{
+    size_t pos = 0;
+    size_t oldValueLen = oldValue.length();
+    size_t newValueLen = newValue.length();
+    while ((pos = str.find(oldValue, pos)) != std::wstring::npos) {
+        str.replace(pos, oldValueLen, newValue);
+        pos += newValueLen;
+    }
+}
+
 HRESULT IISConfigUtil::BuildAppCmdCommand(const vector<pair<wstring, wstring>>& vecSet, vector<pair<wstring, wstring>>::iterator& envVecIter, WCHAR* pstrAppPoolName, wstring& pStrCmd, APPCMD_CMD_TYPE appCmdType)
 {
     HRESULT hr = S_OK;
@@ -143,6 +154,12 @@ HRESULT IISConfigUtil::BuildAppCmdCommand(const vector<pair<wstring, wstring>>& 
     {
         wstring strEnvName  = envVecIter->first;
         wstring strEnvValue = envVecIter->second;
+
+        //
+        // Handle values that have single and double quotes
+        //
+        Replace(strEnvValue, L"'", L"''");
+        Replace(strEnvValue, L"\"", L"\"\"\"");
 
         if ((pStrCmd.length() + strEnvName.length() + strEnvValue.length()) > APPCMD_MAX_SIZE)
         {

--- a/src/ServiceMonitor/IISConfigUtil.h
+++ b/src/ServiceMonitor/IISConfigUtil.h
@@ -25,6 +25,7 @@ private:
     HRESULT RunCommand(std::wstring& pstrCmd, BOOL fIgnoreError);
     HRESULT BuildAppCmdCommand(const std::vector<std::pair<std::wstring, std::wstring>>& vecSet, std::vector<std::pair<std::wstring, std::wstring>>::iterator& envVecIter, WCHAR* pstrAppPoolName, std::wstring& pStrCmd, APPCMD_CMD_TYPE appcmdType);
     BOOL    FilterEnv(const std::unordered_map<std::wstring, LPTSTR>& filter, LPCTSTR strEnvName, LPCTSTR strEnvValue);
+    void    Replace(std::wstring& str, std::wstring oldValue, std::wstring newValue);
     TCHAR*  m_pstrSysDirPath;
 };
 


### PR DESCRIPTION
Fixes https://github.com/Microsoft/IIS.ServiceMonitor/issues/40

Entity Framework connection strings use single quotes so this was how the issue was discovered.