### PR TITLE
Fix BinSkim issues of BA2024 and BA2008

### DIFF
--- a/src/ServiceMonitor/ServiceMonitor.vcxproj
+++ b/src/ServiceMonitor/ServiceMonitor.vcxproj
@@ -56,6 +56,7 @@
     <PlatformToolset>v141</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
+    <SpectreMitigation>Spectre</SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -143,6 +144,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -170,7 +172,7 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ServiceMonitor.rc">
-      <PreprocessorDefinitions  Condition=" '$(BuildMinorVersion)' != '' ">SM_BUILDMINORVERSION=$(BuildMinorVersion)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition=" '$(BuildMinorVersion)' != '' ">SM_BUILDMINORVERSION=$(BuildMinorVersion)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This change will fix #45 
- Enable control flow guard
- Enable code generation mitigations for speculative execution
side-channel attack (Spectre) vulnerabilities.

After this change, it is required to install runtime libraries that have
been built to provide Spectre mitigations. See https://aka.ms/Ofhn4ch