### PR TITLE
Update iis.servicemonitor.build.dev.yml for Azure Pipelines

### DIFF
--- a/.pipelines/iis.servicemonitor.build.dev.yml
+++ b/.pipelines/iis.servicemonitor.build.dev.yml
@@ -9,4 +9,4 @@ jobs:
     productMajor: 2
     productMinor: 0
     signType: 'test'
-    publishArtifactInstaller: 'true'
+    publishArtifactInstaller: 'false'


### PR DESCRIPTION
set publishArtifactInstaller to false since there's no installer for service monitor.