### PR TITLE
Exit after waiting until the service stopped

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -214,7 +214,7 @@ HRESULT IISConfigUtil::RunCommand(wstring& pstrCmd, BOOL fIgnoreError)
         //
         // appcmd command failed
         //
-        _tprintf(L"\n[SERVICEMONITOR] APPCMD failed with error code %d\n", dwStatus);
+        _tprintf(L"\nAPPCMD failed with error code %d\n", dwStatus);
         hr = E_FAIL;
     }
 
@@ -244,7 +244,7 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
     lpvEnv = GetEnvironmentStrings();
     if (lpvEnv == NULL)
     {
-        _tprintf(L"[SERVICEMONITOR] Failed to call GetEnvironmentStrings! \n");
+        _tprintf(L"Failed to call GetEnvironmentStrings! \n");
         hr = E_FAIL;
         goto Finished;
     }

--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -214,7 +214,7 @@ HRESULT IISConfigUtil::RunCommand(wstring& pstrCmd, BOOL fIgnoreError)
         //
         // appcmd command failed
         //
-        _tprintf(L"\nAPPCMD failed with error code %d\n", dwStatus);
+        _tprintf(L"\n[SERVICEMONITOR] APPCMD failed with error code %d\n", dwStatus);
         hr = E_FAIL;
     }
 
@@ -244,7 +244,7 @@ HRESULT IISConfigUtil::UpdateEnvironmentVarsToConfig(WCHAR* pstrAppPoolName)
     lpvEnv = GetEnvironmentStrings();
     if (lpvEnv == NULL)
     {
-        _tprintf(L"Failed to call GetEnvironmentStrings! \n");
+        _tprintf(L"[SERVICEMONITOR] Failed to call GetEnvironmentStrings! \n");
         hr = E_FAIL;
         goto Finished;
     }

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -5,7 +5,6 @@
 
 HANDLE g_hStopEvent = INVALID_HANDLE_VALUE;
 
-
 BOOL CtrlHandle(DWORD dwCtrlType)
 {
     switch (dwCtrlType)

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -82,7 +82,7 @@ int __cdecl _tmain(int argc, _TCHAR* argv[])
         goto Finished;
     }
 
-    if (!SetConsoleCtrlHandler((PHANDLER_ROUTINE)CtrlHandle, TRUE))
+    if (!SetConsoleCtrlHandler(CtrlHandle, TRUE))
     {
         hr = HRESULT_FROM_WIN32(GetLastError());
         _tprintf(L"\nERROR: Failed to set control handle with error [%x]\n", hr);

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -121,7 +121,5 @@ Finished:
         CloseHandle(g_hStopEvent);
         g_hStopEvent = INVALID_HANDLE_VALUE;
     }
-
-    _tprintf(L"\nThe process terminated.\n");
     return hr;
 }

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -8,9 +8,6 @@ HANDLE g_hStopEvent = INVALID_HANDLE_VALUE;
 
 BOOL CtrlHandle(DWORD dwCtrlType)
 {
-    HRESULT   hr = S_OK;
-    DWORD     dwWaitResult;
-
     switch (dwCtrlType)
     {
     case CTRL_C_EVENT:

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -18,7 +18,7 @@ BOOL CtrlHandle(DWORD dwCtrlType)
     case CTRL_BREAK_EVENT:
     case CTRL_LOGOFF_EVENT:
     case CTRL_SHUTDOWN_EVENT:
-        _tprintf(L"\nCTRL signal received. The process will terminate after stopping the service.\n");
+        _tprintf(L"\nCTRL signal received. The process will now terminate.\n");
         SetEvent(g_hStopEvent);
         g_hStopEvent = INVALID_HANDLE_VALUE;
         break;

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -7,7 +7,7 @@ HANDLE g_hStopEvent = INVALID_HANDLE_VALUE;
 HANDLE g_hProcessExitEvent = INVALID_HANDLE_VALUE;
 
 
-VOID CtrlHandle(DWORD dwCtrlType)
+BOOL CtrlHandle(DWORD dwCtrlType)
 {
     HRESULT   hr = S_OK;
     DWORD     dwWaitResult;
@@ -36,10 +36,13 @@ VOID CtrlHandle(DWORD dwCtrlType)
             hr = HRESULT_FROM_WIN32(GetLastError());
             _tprintf(L"\nERROR: Stoppoing service wait error [%x]\n", hr);
         }
+
         break;
     default:
-        return;
+        return TRUE;
     }
+
+    return TRUE;
 }
 
 int __cdecl _tmain(int argc, _TCHAR* argv[])

--- a/src/ServiceMonitor/Main.cpp
+++ b/src/ServiceMonitor/Main.cpp
@@ -4,7 +4,6 @@
 #include"stdafx.h"
 
 HANDLE g_hStopEvent = INVALID_HANDLE_VALUE;
-HANDLE g_hProcessExitEvent = INVALID_HANDLE_VALUE;
 
 
 BOOL CtrlHandle(DWORD dwCtrlType)
@@ -22,24 +21,10 @@ BOOL CtrlHandle(DWORD dwCtrlType)
         _tprintf(L"\nCTRL signal received. The process will terminate after stopping the service.\n");
         SetEvent(g_hStopEvent);
         g_hStopEvent = INVALID_HANDLE_VALUE;
-
-        dwWaitResult = WaitForSingleObjectEx(g_hProcessExitEvent, INFINITE, TRUE);
-        switch (dwWaitResult)
-        {
-            // Event object was signaled
-        case WAIT_OBJECT_0:
-        case WAIT_IO_COMPLETION:
-            break;
-
-            // An error occurred
-        default:
-            hr = HRESULT_FROM_WIN32(GetLastError());
-            _tprintf(L"\nERROR: Stoppoing service wait error [%x]\n", hr);
-        }
-
         break;
+
     default:
-        return TRUE;
+        break;
     }
 
     return TRUE;
@@ -138,7 +123,5 @@ Finished:
     }
 
     _tprintf(L"\nThe process terminated.\n");
-    SetEvent(g_hProcessExitEvent);
-    g_hProcessExitEvent = INVALID_HANDLE_VALUE;
     return hr;
 }

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -9,7 +9,7 @@ VOID CALLBACK Service_Monitor::NotifyCallBack(PVOID parameter)
 {
     PSERVICE_NOTIFY pSNotify = (PSERVICE_NOTIFY)parameter;
     HANDLE hEvent = (HANDLE) pSNotify->pContext;
-    _tprintf(L"\nService Change Status Notify Callback is called for service '%s' with status '%d'",
+    _tprintf(L"\n[SERVICEMONITOR] Service Change Status Notify Callback is called for service '%s' with status '%d'",
         pSNotify->pszServiceNames, pSNotify->ServiceStatus.dwCurrentState);
     if (hEvent != NULL) 
     {
@@ -29,7 +29,7 @@ HRESULT Service_Monitor::EnsureInitialized()
             if (_hSCManager == NULL)
             {
                 hr = HRESULT_FROM_WIN32(GetLastError());
-                _tprintf(L"\nERROR:Could NOT open server control manager [%x]\n", hr);
+                _tprintf(L"\n[SERVICEMONITOR] ERROR:Could NOT open server control manager [%x]\n", hr);
             }
             else
             {
@@ -111,11 +111,11 @@ HRESULT Service_Monitor::StartServiceByName(LPCTSTR pServiceName, DWORD dwTimeOu
     Finished:
     if(SUCCEEDED(hr))
     {
-        _tprintf(L"\n Service '%s' started \n", pServiceName);
+        _tprintf(L"\n[SERVICEMONITOR] Service '%s' started \n", pServiceName);
     }
     else
     {
-        _tprintf(L"\nERROR: Failed to start or query status of service '%s' error [%x]\n", pServiceName, hr);
+        _tprintf(L"\n[SERVICEMONITOR] ERROR: Failed to start or query status of service '%s' error [%x]\n", pServiceName, hr);
     }
 
     if (hService != NULL)
@@ -187,11 +187,11 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
     Finished: 
         if (SUCCEEDED(hr))
         {
-            _tprintf(L"\n Service '%s' has been stopped \n", pServiceName);
+            _tprintf(L"\n[SERVICEMONITOR] Service '%s' has been stopped \n", pServiceName);
         }
         else
         {
-            _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
+            _tprintf(L"\n[SERVICEMONITOR] ERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
         }
 
         if (hService != NULL)
@@ -224,7 +224,7 @@ HRESULT Service_Monitor::MonitoringService(LPCTSTR pServiceName, DWORD dwStatus,
     if (dwError != ERROR_SUCCESS)
     {
         hr = HRESULT_FROM_WIN32(dwError);
-        _tprintf(L"\nERROR: fail to register status change callback [%x]\n", hr);
+        _tprintf(L"\n[SERVICEMONITOR] ERROR: fail to register status change callback [%x]\n", hr);
         goto Finished;
     }
 
@@ -239,7 +239,7 @@ HRESULT Service_Monitor::MonitoringService(LPCTSTR pServiceName, DWORD dwStatus,
         // An error occurred
     default:
         hr = HRESULT_FROM_WIN32(GetLastError());
-        _tprintf(L"\nERROR: Monitoring service '%s' wait error [%x]\n", pServiceName, hr);
+        _tprintf(L"\n[SERVICEMONITOR] ERROR: Monitoring service '%s' wait error [%x]\n", pServiceName, hr);
     }
 
 Finished:
@@ -256,7 +256,7 @@ HRESULT Service_Monitor::GetServiceHandle(LPCTSTR pServiceName, SC_HANDLE* pHand
 
     if (pServiceName == NULL)
     {
-        _tprintf(L"\nERROR: Null parameter for GetServiceHandle()\n");
+        _tprintf(L"\n[SERVICEMONITOR] ERROR: Null parameter for GetServiceHandle()\n");
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER);
         goto Finished;
     }

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -133,6 +133,7 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
         DWORD     dwSleepTime = 0;
         DWORD     dwRemainTime = dwTimeOutSeconds;
         SERVICE_STATUS_PROCESS sStatus;
+        BOOL      serviceStopped = false;
 
         hr = GetServiceHandle(pServiceName, &hService);
         if (SUCCEEDED(hr)) 
@@ -167,6 +168,7 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
                         hr = HRESULT_FROM_WIN32(GetLastError());
                         goto Finished;
                     }
+                    serviceStopped = true;
                 }
                 else
                 {
@@ -191,7 +193,14 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
         }
         else
         {
-            _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
+            if (serviceStopped)
+            {
+                _tprintf(L"\nINFO: Failed to query status after stopping service '%s' error [%x]\n", pServiceName, hr);
+            }
+            else
+            {
+                _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
+            }
         }
 
         if (hService != NULL)

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -133,7 +133,6 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
         DWORD     dwSleepTime = 0;
         DWORD     dwRemainTime = dwTimeOutSeconds;
         SERVICE_STATUS_PROCESS sStatus;
-        BOOL      serviceStopped = false;
 
         hr = GetServiceHandle(pServiceName, &hService);
         if (SUCCEEDED(hr)) 
@@ -168,7 +167,7 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
                         hr = HRESULT_FROM_WIN32(GetLastError());
                         goto Finished;
                     }
-                    serviceStopped = true;
+                    _tprintf(L"\nStopping service '%s'\n", pServiceName);
                 }
                 else
                 {
@@ -193,14 +192,7 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
         }
         else
         {
-            if (serviceStopped)
-            {
-                _tprintf(L"\nINFO: Failed to query status after stopping service '%s' error [%x]\n", pServiceName, hr);
-            }
-            else
-            {
-                _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
-            }
+            _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
         }
 
         if (hService != NULL)

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -111,7 +111,7 @@ HRESULT Service_Monitor::StartServiceByName(LPCTSTR pServiceName, DWORD dwTimeOu
     Finished:
     if(SUCCEEDED(hr))
     {
-        _tprintf(L"\nService '%s' started \n", pServiceName);
+        _tprintf(L"\n Service '%s' started \n", pServiceName);
     }
     else
     {
@@ -187,7 +187,7 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
     Finished: 
         if (SUCCEEDED(hr))
         {
-            _tprintf(L"\nService '%s' has been stopped \n", pServiceName);
+            _tprintf(L"\n Service '%s' has been stopped \n", pServiceName);
         }
         else
         {

--- a/src/ServiceMonitor/ServiceMonitor.cpp
+++ b/src/ServiceMonitor/ServiceMonitor.cpp
@@ -9,7 +9,7 @@ VOID CALLBACK Service_Monitor::NotifyCallBack(PVOID parameter)
 {
     PSERVICE_NOTIFY pSNotify = (PSERVICE_NOTIFY)parameter;
     HANDLE hEvent = (HANDLE) pSNotify->pContext;
-    _tprintf(L"\n[SERVICEMONITOR] Service Change Status Notify Callback is called for service '%s' with status '%d'",
+    _tprintf(L"\nService Change Status Notify Callback is called for service '%s' with status '%d'",
         pSNotify->pszServiceNames, pSNotify->ServiceStatus.dwCurrentState);
     if (hEvent != NULL) 
     {
@@ -29,7 +29,7 @@ HRESULT Service_Monitor::EnsureInitialized()
             if (_hSCManager == NULL)
             {
                 hr = HRESULT_FROM_WIN32(GetLastError());
-                _tprintf(L"\n[SERVICEMONITOR] ERROR:Could NOT open server control manager [%x]\n", hr);
+                _tprintf(L"\nERROR:Could NOT open server control manager [%x]\n", hr);
             }
             else
             {
@@ -111,11 +111,11 @@ HRESULT Service_Monitor::StartServiceByName(LPCTSTR pServiceName, DWORD dwTimeOu
     Finished:
     if(SUCCEEDED(hr))
     {
-        _tprintf(L"\n[SERVICEMONITOR] Service '%s' started \n", pServiceName);
+        _tprintf(L"\nService '%s' started \n", pServiceName);
     }
     else
     {
-        _tprintf(L"\n[SERVICEMONITOR] ERROR: Failed to start or query status of service '%s' error [%x]\n", pServiceName, hr);
+        _tprintf(L"\nERROR: Failed to start or query status of service '%s' error [%x]\n", pServiceName, hr);
     }
 
     if (hService != NULL)
@@ -187,11 +187,11 @@ HRESULT Service_Monitor::StopServiceByName(LPCTSTR pServiceName, DWORD dwTimeOut
     Finished: 
         if (SUCCEEDED(hr))
         {
-            _tprintf(L"\n[SERVICEMONITOR] Service '%s' has been stopped \n", pServiceName);
+            _tprintf(L"\nService '%s' has been stopped \n", pServiceName);
         }
         else
         {
-            _tprintf(L"\n[SERVICEMONITOR] ERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
+            _tprintf(L"\nERROR: Failed to stop or query status of service '%s' error [%x]\n", pServiceName, hr);
         }
 
         if (hService != NULL)
@@ -224,7 +224,7 @@ HRESULT Service_Monitor::MonitoringService(LPCTSTR pServiceName, DWORD dwStatus,
     if (dwError != ERROR_SUCCESS)
     {
         hr = HRESULT_FROM_WIN32(dwError);
-        _tprintf(L"\n[SERVICEMONITOR] ERROR: fail to register status change callback [%x]\n", hr);
+        _tprintf(L"\nERROR: fail to register status change callback [%x]\n", hr);
         goto Finished;
     }
 
@@ -239,7 +239,7 @@ HRESULT Service_Monitor::MonitoringService(LPCTSTR pServiceName, DWORD dwStatus,
         // An error occurred
     default:
         hr = HRESULT_FROM_WIN32(GetLastError());
-        _tprintf(L"\n[SERVICEMONITOR] ERROR: Monitoring service '%s' wait error [%x]\n", pServiceName, hr);
+        _tprintf(L"\nERROR: Monitoring service '%s' wait error [%x]\n", pServiceName, hr);
     }
 
 Finished:
@@ -256,7 +256,7 @@ HRESULT Service_Monitor::GetServiceHandle(LPCTSTR pServiceName, SC_HANDLE* pHand
 
     if (pServiceName == NULL)
     {
-        _tprintf(L"\n[SERVICEMONITOR] ERROR: Null parameter for GetServiceHandle()\n");
+        _tprintf(L"\nERROR: Null parameter for GetServiceHandle()\n");
         hr = HRESULT_FROM_WIN32(ERROR_INVALID_PARAMETER);
         goto Finished;
     }


### PR DESCRIPTION
1. Update the return type of CtrlHandle() referring to https://docs.microsoft.com/en-us/windows/console/handlerroutine#return-value
2. Updated one error message after service stopping is completed in order to avoid the confusion with the error message.