### PR TITLE
Use the ADO build revision token for the name of the build

### DIFF
--- a/.pipelines/iis.servicemonitor.build.dev.yml
+++ b/.pipelines/iis.servicemonitor.build.dev.yml
@@ -1,4 +1,4 @@
-name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.rr)
+name: $(Rev:rr)
 
 pr:
   - master
@@ -24,6 +24,7 @@ jobs:
     solution: '**\ServiceMonitor.sln'
     productMajor: 2
     productMinor: 0
+    buildMinor: $(Build.BuildNumber)
     signType: 'test'
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'false'

--- a/src/ServiceMonitor/ServiceMonitor.vcxproj
+++ b/src/ServiceMonitor/ServiceMonitor.vcxproj
@@ -169,7 +169,7 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ServiceMonitor.rc">
-      <PreprocessorDefinitions  Condition=" '$(BuildMinorVersion)' != '' ">SM_BUILDMINORVERSION=$(BuildMinorVersion)</PreprocessorDefinitions>
+      <PreprocessorDefinitions  Condition=" '$(BUILD_MINOR)' != '' ">SM_BUILDMINORVERSION=$(BUILD_MINOR)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Service monitor msbuild projects pull the build minor version on the binary from the build name/number that ADO assigns to the build job and expect that to be the $(Rev) token used in build names.

This change updates the build name/number in the yml file to use the $(Rev) token that can be used in the build minor version.
