### PR TITLE
Fix build version number of servicemonitor.exe in official build Binary 

### DIFF
--- a/.pipelines/iis.servicemonitor.build.official.yml
+++ b/.pipelines/iis.servicemonitor.build.official.yml
@@ -18,6 +18,7 @@ jobs:
     solution: '**\ServiceMonitor.sln'
     productMajor: 1
     productMinor: 0
+    buildMinor: $(Build.BuildNumber)
     signType: 'real'
     indexSourcesAndPublishSymbols: 'true'
     publishArtifactInstallers: 'false'


### PR DESCRIPTION
A previous PR fixed the build version number to use the value of the $(rev) varialble. But the fix did not update the official build definition's YAML file only the dev YAML file.

This PR also updates the official build YAML with the fix.