### PR TITLE
Use $rev as build id

### DIFF
--- a/.pipelines/iis.servicemonitor.build.official.yml
+++ b/.pipelines/iis.servicemonitor.build.official.yml
@@ -1,4 +1,4 @@
-name: $(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.rr)
+name: $(Rev:rr)
 
 pr: none
 trigger: none


### PR DESCRIPTION
Update name of official build to $rev. This ensured build id is set to $rev and can be passed as minot build version parameter.