### PR TITLE
replace % by %25 while building appcmd command

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -163,6 +163,11 @@ HRESULT IISConfigUtil::BuildAppCmdCommand(const vector<pair<wstring, wstring>>& 
         Replace(strEnvName, L"\"", L"\"\"\"");
         Replace(strEnvValue, L"'", L"''");
         Replace(strEnvValue, L"\"", L"\"\"\"");
+        
+        //
+        // Handle values with a % sign, appcmd interprets these as hex characters
+        //
+        Replace(strEnvValue, L"%", L"%25");
 
         if ((pStrCmd.length() + strEnvName.length() + strEnvValue.length()) > APPCMD_MAX_SIZE)
         {


### PR DESCRIPTION
Resolves #71, verified on my own windows 2019 image. 

Assuming the % escaping behavior is not version-specific for appcmd.exe (unfortunately this is not verifiable for me), I think this fix is relatively safe.