### PR TITLE
Allow longer timeout for APPCMD to finish

### DIFF
--- a/src/ServiceMonitor/IISConfigUtil.cpp
+++ b/src/ServiceMonitor/IISConfigUtil.cpp
@@ -226,9 +226,9 @@ HRESULT IISConfigUtil::RunCommand(wstring& pstrCmd, BOOL fIgnoreError)
     }
 
     //
-    // wait for at most 5 seconds to allow APPCMD finish
+    // wait for at most 30 seconds to allow APPCMD finish
     //
-    WaitForSingleObject(pi.hProcess, 5000);
+    WaitForSingleObject(pi.hProcess, 30000);
     if ((!GetExitCodeProcess(pi.hProcess, &dwStatus) || dwStatus != 0) && (!fIgnoreError))
     {
         //


### PR DESCRIPTION
Update timeout for APPCMD to 30 seconds, container is failing to start up because APPCMD is taking too long and ServiceMonitor is bombing.