### PR TITLE
Update servicemonitor to build with VS2022.

### DIFF
--- a/.pipelines/iis.servicemonitor.build.dev.yml
+++ b/.pipelines/iis.servicemonitor.build.dev.yml
@@ -19,7 +19,7 @@ resources:
 jobs:
 - template: .azure\templates\build.yml@MicrosoftIISCommon
   parameters:
-    agentPoolName: 'VSEngSS-MicroBuild2017'
+    agentPoolName: 'VSEngSS-MicroBuild2022-1ES'
     agentPoolDemandTeam: ''
     solution: '**\ServiceMonitor.sln'
     productMajor: 2

--- a/.pipelines/iis.servicemonitor.build.official.yml
+++ b/.pipelines/iis.servicemonitor.build.official.yml
@@ -8,12 +8,12 @@ resources:
     - repository: MicrosoftIISCommon
       type: github
       name: Microsoft/IIS.Common
-      endpoint: GitHub-IIS-PAT
+      endpoint: GitHub-IIS-Token
 
 jobs:
 - template: .azure\templates\build.yml@MicrosoftIISCommon
   parameters:
-    agentPoolName: 'VSEngSS-MicroBuild2017'
+    agentPoolName: 'VSEngSS-MicroBuild2022-1ES'
     agentPoolDemandTeam: ''
     solution: '**\ServiceMonitor.sln'
     productMajor: 1

--- a/NuGet.config
+++ b/NuGet.config
@@ -3,4 +3,9 @@
   <config>
     <add key="repositoryPath" value="packages" />
   </config>
+
+  <packageSources>
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
 </configuration>

--- a/src/ServiceMonitor/ServiceMonitor.vcxproj
+++ b/src/ServiceMonitor/ServiceMonitor.vcxproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" />
+  <Import Project="..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" Condition="Exists('..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -23,36 +23,36 @@
     <ProjectGuid>{EFAE236B-EFB4-413C-8EEE-09F211558AC1}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>ServiceMonitor</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.15063.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>
     <OutDir>$(RepositoryRoot)bin\$(Configuration)\$(PlatformShortname)\</OutDir>
     <IntDir>$(RepositoryRoot)obj\$(PlatformShortname)\$(Configuration)\$(MSBuildThisFileName)\</IntDir>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -169,7 +169,7 @@
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="ServiceMonitor.rc">
-      <PreprocessorDefinitions  Condition=" '$(BUILD_MINOR)' != '' ">SM_BUILDMINORVERSION=$(BUILD_MINOR)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition=" '$(BUILD_MINOR)' != '' ">SM_BUILDMINORVERSION=$(BUILD_MINOR)</PreprocessorDefinitions>
     </ResourceCompile>
   </ItemGroup>
   <ItemGroup>
@@ -182,13 +182,13 @@
     </FilesToSign>
   </ItemGroup>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
+    <Import Project="..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" Condition="Exists('..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
-    <Error Condition="!Exists('..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props'))" />
+    <Error Condition="!Exists('..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets'))" />
   </Target>
 </Project>

--- a/src/ServiceMonitor/packages.config
+++ b/src/ServiceMonitor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MicroBuild.Core" version="0.2.0" targetFramework="native" developmentDependency="true" />
+  <package id="Microsoft.VisualStudioEng.MicroBuild.Core" version="1.0.0" targetFramework="native" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Changes include updating project files for VS2022 and consuming Microbuild from nuget.org. The build pipeline YAML has beeen updated to use the VS2022 agent pool. 