### PR TITLE
docs: update usage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ for those Environment variable / value pairs present in this list below.
 .\ServiceMonitor.exe w3svc
 ```
 
+OR You can supply your preferred _application pool name_, as opposed to the default one: `DefaultAppPool`.
+
+```
+.\ServiceMonitor.exe w3svc [application_pool_name]
+```
+
 ServiceMonitor is currently distributed as part of the [IIS](https://hub.docker.com/_/microsoft-windows-servercore-iis),
 [ASP.NET](https://hub.docker.com/_/microsoft-dotnet-framework-aspnet), and [WCF](https://hub.docker.com/_/microsoft-dotnet-framework-wcf) images on Docker Hub. We recommend layering your project on top of those official images as running
 ServiceMonitor directly in your Dockerfile. 


### PR DESCRIPTION
Add another way of starting up providing the _application pool name_.

NOTE: re-openning #86 due to CLA check, I think I opened the PR back in the days  before I had signed the CLA.